### PR TITLE
Bugfix/vip card logic

### DIFF
--- a/Map.cpp
+++ b/Map.cpp
@@ -419,7 +419,6 @@ namespace Map {
         RegionList[36].InsertElement(ITEM, 58);
         RegionList[36].InsertElement(ITEM, 59);
         RegionList[36].InsertGoal(37); /* Dr Leo + Queen Magridd cutscene */
-        RegionList[38].InsertGoal(75); /* Demon Bird */
 
         /* Region 37 - Act 7 start, World of Evil */
         RegionList[37].InsertElement(ITEM, ITEM_KING_MAGRIDD);
@@ -432,6 +431,7 @@ namespace Map {
 
         /* Region 38 - Dr Leo + Queen Magridd cutscene */
         RegionList[38].InsertElement(ITEM, ITEM_DR_LEO);
+        RegionList[38].InsertGoal(75); /* Demon Bird */
 
         /* Region 39 - Dazzling Space */
         RegionList[39].InsertElement(ITEM, CHEST_SOUL_BLADE);

--- a/Map.cpp
+++ b/Map.cpp
@@ -427,10 +427,10 @@ namespace Map {
         RegionList[37].InsertElement(ITEM, CHEST_RED_HOT_BALL);
         RegionList[37].InsertElement(ITEM, CHEST_SOUL_ARMOR);
         RegionList[37].InsertGoal(38); /* Soul Armor */
-        RegionList[37].InsertGoal(73); /* Super Bracelet tile */
 
         /* Region 38 - Dr Leo + Queen Magridd cutscene */
         RegionList[38].InsertElement(ITEM, ITEM_DR_LEO);
+        RegionList[38].InsertGoal(73); /* Super Bracelet tile */
         RegionList[38].InsertGoal(75); /* Demon Bird */
 
         /* Region 39 - Dazzling Space */
@@ -954,9 +954,6 @@ namespace Map {
 
         /* Goal 73 - Super Bracelet tile */
         GoalList[73].InsertElement(LAIR, NPC_QUEEN_MAGRIDD);
-        GoalList[73].InsertElement(LAIR, NPC_SOLDIER_WITH_LEO);
-        GoalList[73].InsertElement(LAIR, NPC_SOLDIER_DOK);
-        GoalList[73].InsertElement(LAIR, NPC_DR_LEO);
         GoalList[73].Target = 74;
 
         /* Goal 74 - Greenwood Leaf tile */

--- a/Map.cpp
+++ b/Map.cpp
@@ -954,6 +954,9 @@ namespace Map {
 
         /* Goal 73 - Super Bracelet tile */
         GoalList[73].InsertElement(LAIR, NPC_QUEEN_MAGRIDD);
+        GoalList[73].InsertElement(LAIR, NPC_SOLDIER_WITH_LEO);
+        GoalList[73].InsertElement(LAIR, NPC_SOLDIER_DOK);
+        GoalList[73].InsertElement(LAIR, NPC_DR_LEO);
         GoalList[73].Target = 74;
 
         /* Goal 74 - Greenwood Leaf tile */


### PR DESCRIPTION
Raised to fix issue: https://github.com/LeHulk1/RandoBlazer/issues/9

The defined logic states that the only required check for the Soul Bracelet tile requires the Queen Magridd lair to have spawned, but this can cause the VIP card to spawn there. This causes a potential softlock as the VIP card is required to trigger the cutscene to make her disappear, making the tile accessible.

I've fixed this by moving the goal's dependency to after the cutscene is already in logic.

Also moved a bit of code that appeared to be in the wrong region's block.